### PR TITLE
Rename NoEligableDevicesException to NoEligibleDevicesException

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ NOTE: Make sure that you have read https://developers.yubico.com/U2F/Libraries/U
 [source, java]
 ----
 @GET
-public View startAuthentication(String username) throws NoEligableDevicesException {
+public View startAuthentication(String username) throws NoEligibleDevicesException {
 
     // Generate a challenge for each U2F device that this user has registered
     AuthenticateRequestData requestData

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/U2F.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/U2F.java
@@ -11,7 +11,7 @@ import com.yubico.u2f.crypto.RandomChallengeGenerator;
 import com.yubico.u2f.data.DeviceRegistration;
 import com.yubico.u2f.data.messages.*;
 import com.yubico.u2f.exceptions.DeviceCompromisedException;
-import com.yubico.u2f.exceptions.NoEligableDevicesException;
+import com.yubico.u2f.exceptions.NoEligibleDevicesException;
 import com.yubico.u2f.exceptions.U2fBadInputException;
 
 import java.net.MalformedURLException;
@@ -55,7 +55,7 @@ public class U2F {
         return new RegisterRequestData(appId, devices, primitives, challengeGenerator);
     }
 
-    public AuthenticateRequestData startAuthentication(String appId, Iterable<? extends DeviceRegistration> devices) throws U2fBadInputException, NoEligableDevicesException {
+    public AuthenticateRequestData startAuthentication(String appId, Iterable<? extends DeviceRegistration> devices) throws U2fBadInputException, NoEligibleDevicesException {
         if(validateAppId) {
             AppId.checkIsValid(appId);
         }

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/AuthenticateRequestData.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/AuthenticateRequestData.java
@@ -10,7 +10,7 @@ import com.yubico.u2f.crypto.ChallengeGenerator;
 import com.yubico.u2f.data.DeviceRegistration;
 import com.yubico.u2f.data.messages.json.JsonSerializable;
 import com.yubico.u2f.data.messages.json.Persistable;
-import com.yubico.u2f.exceptions.NoEligableDevicesException;
+import com.yubico.u2f.exceptions.NoEligibleDevicesException;
 import com.yubico.u2f.exceptions.U2fBadInputException;
 
 import java.util.List;
@@ -29,7 +29,7 @@ public class AuthenticateRequestData extends JsonSerializable implements Persist
         this.authenticateRequests = authenticateRequests;
     }
 
-    public AuthenticateRequestData(String appId, Iterable<? extends DeviceRegistration> devices, U2fPrimitives u2f, ChallengeGenerator challengeGenerator) throws U2fBadInputException, NoEligableDevicesException {
+    public AuthenticateRequestData(String appId, Iterable<? extends DeviceRegistration> devices, U2fPrimitives u2f, ChallengeGenerator challengeGenerator) throws U2fBadInputException, NoEligibleDevicesException {
         ImmutableList.Builder<AuthenticateRequest> requestBuilder = ImmutableList.builder();
         byte[] challenge = challengeGenerator.generateChallenge();
         for (DeviceRegistration device : devices) {
@@ -41,9 +41,9 @@ public class AuthenticateRequestData extends JsonSerializable implements Persist
 
         if (authenticateRequests.isEmpty()) {
             if(Iterables.isEmpty(devices)) {
-                throw new NoEligableDevicesException(devices, "No devices registrered");
+                throw new NoEligibleDevicesException(devices, "No devices registrered");
             } else {
-                throw new NoEligableDevicesException(devices, "All devices compromised");
+                throw new NoEligibleDevicesException(devices, "All devices compromised");
             }
         }
     }

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/exceptions/NoEligableDevicesException.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/exceptions/NoEligableDevicesException.java
@@ -5,6 +5,10 @@ import com.yubico.u2f.data.DeviceRegistration;
 
 import java.util.List;
 
+/**
+ * @deprecated use {@link NoEligibleDevicesException}
+ */
+@Deprecated
 public class NoEligableDevicesException extends Exception {
     private final List<DeviceRegistration> devices;
 

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/exceptions/NoEligibleDevicesException.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/exceptions/NoEligibleDevicesException.java
@@ -1,0 +1,19 @@
+package com.yubico.u2f.exceptions;
+
+import com.google.common.collect.ImmutableList;
+import com.yubico.u2f.data.DeviceRegistration;
+
+import java.util.List;
+
+@SuppressWarnings("deprecation")
+public class NoEligibleDevicesException extends NoEligableDevicesException {
+
+    public NoEligibleDevicesException(Iterable<? extends DeviceRegistration> devices, String message, Throwable cause) {
+        super(devices, message, cause);
+    }
+
+    public NoEligibleDevicesException(Iterable<? extends DeviceRegistration> devices, String message) {
+        super(devices, message);
+    }
+
+}

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/U2FTest.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/U2FTest.java
@@ -7,7 +7,7 @@ import com.yubico.u2f.data.messages.AuthenticateRequest;
 import com.yubico.u2f.data.messages.AuthenticateRequestData;
 import com.yubico.u2f.data.messages.AuthenticateResponse;
 import com.yubico.u2f.exceptions.DeviceCompromisedException;
-import com.yubico.u2f.exceptions.NoEligableDevicesException;
+import com.yubico.u2f.exceptions.NoEligibleDevicesException;
 import com.yubico.u2f.exceptions.U2fBadInputException;
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ public class U2FTest {
         u2f.startRegistration(APP_ID_ENROLL, ImmutableList.of(deviceRegistration));
     }
 
-    @Test(expected = NoEligableDevicesException.class)
+    @Test(expected = NoEligibleDevicesException.class)
     public void startAuthentication_compromisedDevices() throws Exception {
         DeviceRegistration deviceRegistration = new DeviceRegistration(KEY_HANDLE_BASE64, USER_PUBLIC_KEY_AUTHENTICATE_HEX, ATTESTATION_CERTIFICATE, 0);
         deviceRegistration.markCompromised();

--- a/u2flib-server-demo/src/main/java/demo/Resource.java
+++ b/u2flib-server-demo/src/main/java/demo/Resource.java
@@ -10,7 +10,7 @@ import com.yubico.u2f.data.messages.AuthenticateResponse;
 import com.yubico.u2f.data.messages.RegisterRequestData;
 import com.yubico.u2f.data.messages.RegisterResponse;
 import com.yubico.u2f.exceptions.DeviceCompromisedException;
-import com.yubico.u2f.exceptions.NoEligableDevicesException;
+import com.yubico.u2f.exceptions.NoEligibleDevicesException;
 import demo.view.AuthenticationView;
 import demo.view.RegistrationView;
 import io.dropwizard.views.View;
@@ -60,7 +60,7 @@ public class Resource {
 
     @Path("startAuthentication")
     @GET
-    public View startAuthentication(@QueryParam("username") String username) throws NoEligableDevicesException {
+    public View startAuthentication(@QueryParam("username") String username) throws NoEligibleDevicesException {
         AuthenticateRequestData authenticateRequestData = u2f.startAuthentication(APP_ID, getRegistrations(username));
         requestStorage.put(authenticateRequestData.getRequestId(), authenticateRequestData.toJson());
         return new AuthenticationView(authenticateRequestData.toJson(), username);


### PR DESCRIPTION
I've preserved the old class and marked it as deprecated, and created NoEligibleDevicesException with extends the old class, in order to preserve backwards compatibility.