### PR TITLE
Decode Base64 data with padding as well

### DIFF
--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/util/U2fB64Encoding.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/util/U2fB64Encoding.java
@@ -3,13 +3,14 @@ package com.yubico.u2f.data.messages.key.util;
 import com.google.common.io.BaseEncoding;
 
 public class U2fB64Encoding {
-    private final static BaseEncoding U2F_ENCODING = BaseEncoding.base64Url().omitPadding();
+    private final static BaseEncoding BASE64_ENCODER = BaseEncoding.base64Url().omitPadding();
+    private final static BaseEncoding BASE64_DECODER = BaseEncoding.base64Url();
 
     public static String encode(byte[] decoded) {
-        return U2F_ENCODING.encode(decoded);
+        return BASE64_ENCODER.encode(decoded);
     }
 
     public static byte[] decode(String encoded) {
-        return U2F_ENCODING.decode(encoded);
+        return BASE64_DECODER.decode(encoded);
     }
 }

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/data/messages/key/util/U2fB64EncodingTest.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/data/messages/key/util/U2fB64EncodingTest.java
@@ -1,0 +1,29 @@
+package com.yubico.u2f.data.messages.key.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class U2fB64EncodingTest {
+    @Test
+    public void encodeTest() {
+        byte[] input = "Test".getBytes();
+        String base64Data = U2fB64Encoding.encode(input);
+
+        // No padding.
+        assertEquals("VGVzdA", base64Data);
+    }
+
+    @Test
+    public void decodeTest() {
+        String base64Data = "VGVzdA";
+        String base64DataWithPadding = "VGVzdA==";
+
+        // Verify that Base64 data with and without padding ('=') are decoded correctly.
+        String out1 = new String(U2fB64Encoding.decode(base64Data));
+        String out2 = new String(U2fB64Encoding.decode(base64DataWithPadding));
+
+        assertEquals(out1, out2);
+        assertEquals(out1, "Test");
+    }
+}


### PR DESCRIPTION
By default Base64 encoded data is emitted by this library with the padding ('=') omitted (which is fine), but there is no guarantee that inbound data omits the padding character as well.

Tools such as Yubico's own `u2f-host` generate Base64 responses with padding. This commit makes such input valid in addition to the existing behaviour.