### PR TITLE
Add @JsonIgnore to getter

### DIFF
--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
@@ -10,8 +10,8 @@
 package com.yubico.u2f.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -70,6 +70,7 @@ public class DeviceRegistration extends JsonSerializable implements Serializable
         return publicKey;
     }
 
+    @JsonIgnore
     public X509Certificate getAttestationCertificate() throws CertificateException, NoSuchFieldException {
         if (attestationCert == null) {
             throw new NoSuchFieldException();

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/data/DeviceRegistrationTest.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/data/DeviceRegistrationTest.java
@@ -1,13 +1,13 @@
 package com.yubico.u2f.data;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.yubico.u2f.data.messages.key.Client;
 import com.yubico.u2f.exceptions.InvalidDeviceCounterException;
 import com.yubico.u2f.softkey.SoftKey;
 import org.junit.Test;
 
-import static com.yubico.u2f.testdata.GnubbyKey.ATTESTATION_CERTIFICATE;
-import static com.yubico.u2f.testdata.TestVectors.KEY_HANDLE_BASE64;
-import static com.yubico.u2f.testdata.TestVectors.USER_PUBLIC_KEY_AUTHENTICATE_HEX;
 import static junit.framework.Assert.fail;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -25,6 +25,19 @@ public class DeviceRegistrationTest {
         assertEquals(deviceRegistration.getKeyHandle(), deserializedDeviceRegistration.getKeyHandle());
         assertEquals(deviceRegistration.getPublicKey(), deserializedDeviceRegistration.getPublicKey());
         assertEquals(deviceRegistration.getCounter(), deserializedDeviceRegistration.getCounter());
+    }
+
+    @Test
+    public void serializationRoundTripWithJackson() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.disable(DeserializationFeature.UNWRAP_ROOT_VALUE);
+        objectMapper.disable(SerializationFeature.WRAP_ROOT_VALUE);
+
+        DeviceRegistration input = getDeviceRegistration();
+        String json = objectMapper.writeValueAsString(input);
+        DeviceRegistration output = objectMapper.readValue(json, DeviceRegistration.class);
+
+        assertEquals(input, output);
     }
 
     @Test


### PR DESCRIPTION
Because DeviceRegistration uses @JsonProperty to mark fields as getters
and setters for the JSON serializer, the getter methods should be
ignored. If `#getAttestationCertificate` is not marked as ignorable,
Jackson will attempt to serialize an X509Certificate instance, which
will fail. Instead the string representation of the certificate should
be serialized.

This is not a problem in this library, because `#toJson` is called
directly, but other projects depending on this class to serialize neatly
with Jackson need the extra annotations.