### PR TITLE
Client validation bugfixes

### DIFF
--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
@@ -71,7 +71,7 @@ public class DeviceRegistration extends JsonSerializable implements Serializable
     }
 
     @JsonIgnore
-    public X509Certificate getAttestationCertificate() throws CertificateException, NoSuchFieldException {
+    public X509Certificate getAttestationCertificate() throws U2fBadInputException, CertificateException, NoSuchFieldException {
         if (attestationCert == null) {
             throw new NoSuchFieldException();
         }

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
@@ -42,7 +42,7 @@ public class DeviceRegistration extends JsonSerializable implements Serializable
     private boolean compromised;
 
     @JsonCreator
-    private DeviceRegistration(@JsonProperty("keyHandle") String keyHandle, @JsonProperty("publicKey") String publicKey, @JsonProperty("attestationCert") String attestationCert, @JsonProperty("counter") long counter, @JsonProperty("compromised") boolean compromised) {
+    public DeviceRegistration(@JsonProperty("keyHandle") String keyHandle, @JsonProperty("publicKey") String publicKey, @JsonProperty("attestationCert") String attestationCert, @JsonProperty("counter") long counter, @JsonProperty("compromised") boolean compromised) {
         this.keyHandle = keyHandle;
         this.publicKey = publicKey;
         this.attestationCert = attestationCert;

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/DeviceRegistration.java
@@ -115,6 +115,8 @@ public class DeviceRegistration extends JsonSerializable implements Serializable
             // do nothing
         } catch (NoSuchFieldException e) {
             // do nothing
+        } catch (U2fBadInputException e) {
+            // do nothing
         }
         return MoreObjects.toStringHelper(this)
                 .omitNullValues()

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/ClientData.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/ClientData.java
@@ -49,8 +49,15 @@ public class ClientData {
         return challenge;
     }
 
-    public String getString(String key) {
-        return data.get(key).asText();
+    private String getString(String key) {
+        JsonNode node = data.get(key);
+        if (node == null) {
+            throw new U2fBadInputException("Bad clientData: missing field " + key);
+        }
+        if (!node.isTextual()) {
+            throw new U2fBadInputException("Bad clientData: field " + key + " not a string");
+        }
+        return node.asText();
     }
 
     public void checkContent(String type, String challenge, Optional<Set<String>> facets) throws U2fBadInputException {

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/RawAuthenticateResponse.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/RawAuthenticateResponse.java
@@ -18,6 +18,7 @@ import com.yubico.u2f.data.messages.key.util.ByteInputStream;
 import com.yubico.u2f.data.messages.key.util.U2fB64Encoding;
 import com.yubico.u2f.exceptions.U2fBadInputException;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 /**
@@ -45,12 +46,16 @@ public class RawAuthenticateResponse {
 
     public static RawAuthenticateResponse fromBase64(String rawDataBase64, Crypto crypto) throws U2fBadInputException {
         ByteInputStream bytes = new ByteInputStream(U2fB64Encoding.decode(rawDataBase64));
-        return new RawAuthenticateResponse(
-                bytes.readSigned(),
-                bytes.readInteger(),
-                bytes.readAll(),
-                crypto
-        );
+        try {
+            return new RawAuthenticateResponse(
+                    bytes.readSigned(),
+                    bytes.readInteger(),
+                    bytes.readAll(),
+                    crypto
+            );
+        } catch (IOException e) {
+            throw new U2fBadInputException("Truncated authentication data", e);
+        }
     }
 
     public void checkSignature(String appId, String clientData, byte[] publicKey) throws U2fBadInputException {

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/RawAuthenticateResponse.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/RawAuthenticateResponse.java
@@ -43,7 +43,7 @@ public class RawAuthenticateResponse {
         this.crypto = crypto;
     }
 
-    public static RawAuthenticateResponse fromBase64(String rawDataBase64, Crypto crypto) {
+    public static RawAuthenticateResponse fromBase64(String rawDataBase64, Crypto crypto) throws U2fBadInputException {
         ByteInputStream bytes = new ByteInputStream(U2fB64Encoding.decode(rawDataBase64));
         return new RawAuthenticateResponse(
                 bytes.readSigned(),

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/RawRegisterResponse.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/RawRegisterResponse.java
@@ -20,6 +20,7 @@ import com.yubico.u2f.data.messages.key.util.CertificateParser;
 import com.yubico.u2f.data.messages.key.util.U2fB64Encoding;
 import com.yubico.u2f.exceptions.U2fBadInputException;
 
+import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -72,15 +73,15 @@ public class RawRegisterResponse {
 
     public static RawRegisterResponse fromBase64(String rawDataBase64, Crypto crypto) throws U2fBadInputException {
         ByteInputStream bytes = new ByteInputStream(U2fB64Encoding.decode(rawDataBase64));
-        byte reservedByte = bytes.readSigned();
-        if (reservedByte != REGISTRATION_RESERVED_BYTE_VALUE) {
-            throw new U2fBadInputException(
-                    "Incorrect value of reserved byte. Expected: " + REGISTRATION_RESERVED_BYTE_VALUE +
-                            ". Was: " + reservedByte
-            );
-        }
-
         try {
+            byte reservedByte = bytes.readSigned();
+            if (reservedByte != REGISTRATION_RESERVED_BYTE_VALUE) {
+                throw new U2fBadInputException(
+                        "Incorrect value of reserved byte. Expected: " + REGISTRATION_RESERVED_BYTE_VALUE +
+                                ". Was: " + reservedByte
+                );
+            }
+
             return new RawRegisterResponse(
                     bytes.read(65),
                     bytes.read(bytes.readUnsigned()),
@@ -90,6 +91,8 @@ public class RawRegisterResponse {
             );
         } catch (CertificateException e) {
             throw new U2fBadInputException("Malformed attestation certificate", e);
+        } catch (IOException e) {
+            throw new U2fBadInputException("Truncated registration data", e);
         }
     }
 

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/util/ByteInputStream.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/util/ByteInputStream.java
@@ -14,54 +14,33 @@ import java.io.IOException;
 /**
  * Provides an easy way to read a byte array in chunks.
  */
-//  ByteArrayInputStream cannot throw IOExceptions, so this class is converting checked exceptions to unchecked.
 public class ByteInputStream extends DataInputStream {
 
     public ByteInputStream(byte[] data) {
         super(new ByteArrayInputStream(data));
     }
 
-    public byte[] read(int numberOfBytes) {
+    public byte[] read(int numberOfBytes) throws IOException {
         byte[] readBytes = new byte[numberOfBytes];
-        try {
-            readFully(readBytes);
-        } catch (IOException e) {
-            throw new AssertionError();
-        }
+        readFully(readBytes);
         return readBytes;
     }
 
-    public byte[] readAll() {
-        try {
-            byte[] readBytes = new byte[available()];
-            readFully(readBytes);
-            return readBytes;
-        } catch (IOException e) {
-            throw new AssertionError();
-        }
+    public byte[] readAll() throws IOException {
+        byte[] readBytes = new byte[available()];
+        readFully(readBytes);
+        return readBytes;
     }
 
-    public int readInteger() {
-        try {
-            return readInt();
-        } catch (IOException e) {
-            throw new AssertionError();
-        }
+    public int readInteger() throws IOException {
+        return readInt();
     }
 
-    public byte readSigned() {
-        try {
-            return readByte();
-        } catch (IOException e) {
-            throw new AssertionError();
-        }
+    public byte readSigned() throws IOException {
+        return readByte();
     }
 
-    public int readUnsigned() {
-        try {
-            return readUnsignedByte();
-        } catch (IOException e) {
-            throw new AssertionError();
-        }
+    public int readUnsigned() throws IOException {
+        return readUnsignedByte();
     }
 }

--- a/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/util/U2fB64Encoding.java
+++ b/u2flib-server-core/src/main/java/com/yubico/u2f/data/messages/key/util/U2fB64Encoding.java
@@ -1,6 +1,7 @@
 package com.yubico.u2f.data.messages.key.util;
 
 import com.google.common.io.BaseEncoding;
+import com.yubico.u2f.exceptions.U2fBadInputException;
 
 public class U2fB64Encoding {
     private final static BaseEncoding BASE64_ENCODER = BaseEncoding.base64Url().omitPadding();
@@ -11,6 +12,10 @@ public class U2fB64Encoding {
     }
 
     public static byte[] decode(String encoded) {
-        return BASE64_DECODER.decode(encoded);
+        try {
+            return BASE64_DECODER.decode(encoded);
+        } catch (IllegalArgumentException e) {
+            throw new U2fBadInputException("Bad base64 encoding", e);
+        }
     }
 }

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/U2fPrimitivesTest.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/U2fPrimitivesTest.java
@@ -97,6 +97,17 @@ public class U2fPrimitivesTest {
         u2f.finishAuthentication(authentication, response, new DeviceRegistration(KEY_HANDLE_BASE64, USER_PUBLIC_KEY_AUTHENTICATE_HEX, ATTESTATION_CERTIFICATE, 0));
     }
 
+    @Test(expected = U2fBadInputException.class)
+    public void finishAuthentication_truncatedData() throws Exception {
+        AuthenticateRequest authentication = new AuthenticateRequest(SERVER_CHALLENGE_SIGN_BASE64,
+          APP_ID_SIGN, KEY_HANDLE_BASE64);
+
+        AuthenticateResponse response = new AuthenticateResponse(CLIENT_DATA_AUTHENTICATE_BASE64,
+                "", KEY_HANDLE_BASE64);
+
+        u2f.finishAuthentication(authentication, response, new DeviceRegistration(KEY_HANDLE_BASE64, USER_PUBLIC_KEY_AUTHENTICATE_HEX, ATTESTATION_CERTIFICATE, 0));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void startAuthentication_compromisedDevice() throws Exception {
         RegisterRequest registerRequest = new RegisterRequest(SERVER_CHALLENGE_REGISTER_BASE64, APP_ID_ENROLL);

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/U2fPrimitivesTest.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/U2fPrimitivesTest.java
@@ -15,6 +15,7 @@ import com.yubico.u2f.data.messages.AuthenticateRequest;
 import com.yubico.u2f.data.messages.AuthenticateResponse;
 import com.yubico.u2f.data.messages.RegisterRequest;
 import com.yubico.u2f.data.messages.RegisterResponse;
+import com.yubico.u2f.data.messages.key.util.U2fB64Encoding;
 import com.yubico.u2f.exceptions.U2fBadInputException;
 import com.yubico.u2f.testdata.AcmeKey;
 import com.yubico.u2f.testdata.TestVectors;
@@ -74,6 +75,16 @@ public class U2fPrimitivesTest {
                 SIGN_RESPONSE_DATA_BASE64, SERVER_CHALLENGE_SIGN_BASE64);
 
         u2f.finishAuthentication(authentication, response, new DeviceRegistration(KEY_HANDLE_BASE64, USER_PUBLIC_KEY_AUTHENTICATE_HEX, ATTESTATION_CERTIFICATE, 0), allowedOrigins);
+    }
+
+    @Test(expected = U2fBadInputException.class)
+    public void finishAuthentication_badBase64() throws Exception {
+        AuthenticateRequest authentication = new AuthenticateRequest(SERVER_CHALLENGE_SIGN_BASE64,
+                APP_ID_SIGN, KEY_HANDLE_BASE64);
+
+        AuthenticateResponse response = new AuthenticateResponse("****", "****", "****");
+
+        u2f.finishAuthentication(authentication, response, new DeviceRegistration(KEY_HANDLE_BASE64, USER_PUBLIC_KEY_AUTHENTICATE_HEX, ATTESTATION_CERTIFICATE, 0));
     }
 
     @Test(expected = U2fBadInputException.class)

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/U2fPrimitivesTest.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/U2fPrimitivesTest.java
@@ -76,6 +76,16 @@ public class U2fPrimitivesTest {
         u2f.finishAuthentication(authentication, response, new DeviceRegistration(KEY_HANDLE_BASE64, USER_PUBLIC_KEY_AUTHENTICATE_HEX, ATTESTATION_CERTIFICATE, 0), allowedOrigins);
     }
 
+    @Test(expected = U2fBadInputException.class)
+    public void finishAuthentication_clientDataMissingField() throws Exception {
+        AuthenticateRequest authentication = new AuthenticateRequest(SERVER_CHALLENGE_SIGN_BASE64,
+          APP_ID_SIGN, KEY_HANDLE_BASE64);
+
+        AuthenticateResponse response = new AuthenticateResponse(U2fB64Encoding.encode("{}".getBytes()), "", "");
+
+        u2f.finishAuthentication(authentication, response, new DeviceRegistration(KEY_HANDLE_BASE64, USER_PUBLIC_KEY_AUTHENTICATE_HEX, ATTESTATION_CERTIFICATE, 0));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void startAuthentication_compromisedDevice() throws Exception {
         RegisterRequest registerRequest = new RegisterRequest(SERVER_CHALLENGE_REGISTER_BASE64, APP_ID_ENROLL);

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/data/messages/key/util/U2fB64EncodingTest.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/data/messages/key/util/U2fB64EncodingTest.java
@@ -2,6 +2,8 @@ package com.yubico.u2f.data.messages.key.util;
 
 import org.junit.Test;
 
+import com.yubico.u2f.exceptions.U2fBadInputException;
+
 import static org.junit.Assert.assertEquals;
 
 public class U2fB64EncodingTest {
@@ -18,12 +20,25 @@ public class U2fB64EncodingTest {
     public void decodeTest() {
         String base64Data = "VGVzdA";
         String base64DataWithPadding = "VGVzdA==";
+        String base64DataEmpty = "";
 
         // Verify that Base64 data with and without padding ('=') are decoded correctly.
         String out1 = new String(U2fB64Encoding.decode(base64Data));
         String out2 = new String(U2fB64Encoding.decode(base64DataWithPadding));
+        String out3 = new String(U2fB64Encoding.decode(base64DataEmpty));
 
         assertEquals(out1, out2);
         assertEquals(out1, "Test");
+        assertEquals(out3, "");
+    }
+
+    @Test(expected = U2fBadInputException.class)
+    public void decodeBadAlphabetTest() {
+        U2fB64Encoding.decode("****");
+    }
+
+    @Test(expected = U2fBadInputException.class)
+    public void decodeBadPaddingTest() {
+        U2fB64Encoding.decode("A===");
     }
 }

--- a/u2flib-server-core/src/test/java/com/yubico/u2f/softkey/SoftKey.java
+++ b/u2flib-server-core/src/test/java/com/yubico/u2f/softkey/SoftKey.java
@@ -15,6 +15,7 @@ import com.yubico.u2f.testdata.GnubbyKey;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 
+import java.io.IOException;
 import java.security.*;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
@@ -88,11 +89,15 @@ public final class SoftKey implements Cloneable {
 
     private byte[] stripMetaData(byte[] a) {
         ByteInputStream bis = new ByteInputStream(a);
-        bis.read(3);
-        bis.read(bis.readUnsigned() + 1);
-        int keyLength = bis.readUnsigned();
-        bis.read(1);
-        return bis.read(keyLength - 1);
+        try {
+            bis.read(3);
+            bis.read(bis.readUnsigned() + 1);
+            int keyLength = bis.readUnsigned();
+            bis.read(1);
+            return bis.read(keyLength - 1);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
     }
 
     public RawAuthenticateResponse authenticate(AuthenticateRequest authenticateRequest) throws Exception {


### PR DESCRIPTION
Bugfixes for several nasty errors handling client input data.

Worst of all, clients can even cause AssertionError to be thrown simply by sending data that's too short.

The tests do not even cover basic cases of malformed client data. The lack of error handling throughout the library is worrying; I've fixed all the errors I could find but it's quite possible there are more.

Also made a persistence constructor public (like all the other objects' constructors) so that it can be used directly if not using JSON for persistence.
