### PR TITLE
Modified build.gradle to bypass issue with missing ossrhUsername and …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,20 @@ import com.yubico.gradle.plugins.signing.GpgSigningPlugin
 
 project.ext.publishEnabled = System.env.CI != 'true'
 
+def v_ossrhUsername="FOO"
+def v_ossrhPassword="BAR"
+
+if (project.hasProperty("ossrhUsername")) {
+  v_ossrhUsername = ossrhUsername
+}
+if (project.hasProperty("ossrhPassword")) {
+  v_ossrhPassword = ossrhPassword
+}
+
 if (publishEnabled) {
   nexusStaging {
-    username = ossrhUsername
-    password = ossrhPassword
+    username = v_ossrhUsername
+    password = v_ossrhPassword
     stagingProfileId = '6c61426e6529d'
   }
 }
@@ -99,11 +109,11 @@ subprojects {
           beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
           repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-            authentication(userName: ossrhUsername, password: ossrhPassword)
+            authentication(userName: v_ossrhUsername, password: v_ossrhPassword)
           }
 
           snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-            authentication(userName: ossrhUsername, password: ossrhPassword)
+            authentication(userName: v_ossrhUsername, password: v_ossrhPassword)
           }
 
           pom.project {


### PR DESCRIPTION
…ossrhPassword in ~/.gradle/gradle.properties

New user trying to follow instructions for running the Demo server.  The publish/snapshot functionality in the parent project build.gradle requires the user to define an ossrhUsername and ossrhPassword property.  If these are not defined the "./gradlew run" instruction results in the following error:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/dgh/git_repos/java-u2flib-server/build.gradle' line: 21

* What went wrong:
A problem occurred evaluating root project 'u2flib-server-parent'.
> Could not get unknown property 'ossrhUsername' for NexusStagingExtension(serverUrl:https://oss.sonatype.org/service/local/, username:null, password:null, packageGroup:null, stagingProfileId:null, numberOfRetries:20, delayBetweenRetriesInMillis:2000) of type io.codearte.gradle.nexus.NexusStagingExtension.
```

Since these properties are not required to build/run the demo server, the attached commit sets default values of FOO/BAR for these properties to allow an errorless build.  An alternative would be to modify the README and instructions to tell the user they must create a gradle.properties files with the required properties.