### PR TITLE
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.9.2

### DIFF
--- a/u2flib-server-core/pom.xml
+++ b/u2flib-server-core/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.9.2</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixes CVE-2019-14379, CVE-2019-14439 and CVE-2019-12814.